### PR TITLE
Add Colab badge to notebook

### DIFF
--- a/notebooks/colab_build.ipynb
+++ b/notebooks/colab_build.ipynb
@@ -2,24 +2,25 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "e715adef",
    "metadata": {
     "id": "overview"
    },
    "source": [
-    "# Periodic Table EPUB build (Colab)",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/<your-github-username>/makePeriodicTableEPUB/blob/work/notebooks/colab_build.ipynb)\n",
     "\n",
-    "This notebook reproduces the full EPUB build pipeline described in [`spec.md`](../spec.md) using Google Colab's default Python runtime.",
+    "<small>Replace `<your-github-username>` with the GitHub account that hosts this repository to make the badge link work.</small>\n",
     "\n",
-    "**Usage notes**:",
-    "\n",
-    "- Open this notebook in Google Colab (File → Open notebook → GitHub).",
-    "- (Optional) Connect your Google Drive if you want to persist the generated EPUB/cover files.",
-    "- Run the cells from top to bottom; the pipeline will download the latest Wikipedia data, normalize it, build the SVG cover, rasterize it, and assemble the EPUB package inside `book/dist/`."
+    "# Periodic Table EPUB build (Colab)\n",
+    "This notebook reproduces the full EPUB build pipeline described in [`spec.md`](../spec.md) using Google Colab's default Python runtime.\n",
+    "**Usage notes**:\n",
+    "- Open this notebook in Google Colab (File → Open notebook → GitHub).- (Optional) Connect your Google Drive if you want to persist the generated EPUB/cover files.- Run the cells from top to bottom; the pipeline will download the latest Wikipedia data, normalize it, build the SVG cover, rasterize it, and assemble the EPUB package inside `book/dist/`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "de0b8165",
    "metadata": {
     "id": "pip-install",
     "tags": [
@@ -34,18 +35,19 @@
   },
   {
    "cell_type": "markdown",
+   "id": "39314563",
    "metadata": {
     "id": "env-notes"
    },
    "source": [
-    "## Optional: Mount Google Drive",
-    "\n",
+    "## Optional: Mount Google Drive\n",
     "Uncomment the cell below if you want the generated assets to be saved to Google Drive instead of the Colab ephemeral filesystem."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "28a48dcc",
    "metadata": {
     "id": "drive-mount"
    },
@@ -58,18 +60,19 @@
   },
   {
    "cell_type": "markdown",
+   "id": "51a46bd9",
    "metadata": {
     "id": "pipeline"
    },
    "source": [
-    "## Build the EPUB",
-    "\n",
+    "## Build the EPUB\n",
     "The commands below follow the workflow defined in Section 4 of the specification. They can be rerun to refresh the data or rebuild the package after modifying templates or scripts."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6733a2de",
    "metadata": {
     "id": "run-pipeline"
    },
@@ -86,18 +89,19 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e6e5dd14",
    "metadata": {
     "id": "inspect"
    },
    "source": [
-    "## Inspect generated files",
-    "\n",
+    "## Inspect generated files\n",
     "Run the following cell to list the distribution folder and confirm that the EPUB and cover JPEG were produced successfully."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2509c2e8",
    "metadata": {
     "id": "list-dist"
    },


### PR DESCRIPTION
## Summary
- add an "Open in Colab" badge to the top markdown cell of `notebooks/colab_build.ipynb`
- include guidance for updating the badge link to match the GitHub repository owner

## Testing
- not run (notebooks-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d20a1ad2988331ad5421a56cf0f2d1