### PR TITLE
Add logging support to fetch wiki script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ pip install -r requirements.txt
    ```bash
    python scripts/fetch_wiki.py --lang en --page "List of chemical elements"
    ```
+   Add `--log-level DEBUG` to see detailed progress information or `--log-file logs/wiki-fetch.log`
+   to also persist the log to disk.
 2. Normalize the downloaded table into `data/tables.json`:
    ```bash
    python scripts/normalize.py


### PR DESCRIPTION
## Summary
- add configurable logging options to the Wikipedia fetch script
- log request lifecycle for bulk and per-element downloads to aid troubleshooting
- emit warnings and errors with exception details for failed element fetches
- ensure logging configuration always applies and emit a startup info log for each run
- document how to enable verbose logging from the CLI

## Testing
- python scripts/fetch_wiki.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d223ad0d5c83319bed1104084ca85c