### PR TITLE
Use List of chemical elements in Colab pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,22 @@ pip install -r requirements.txt
    ```bash
    python scripts/normalize.py
    ```
-3. Build the cover SVG and rasterize it:
+3. Fetch per-element summaries using the normalized table:
+   ```bash
+   python scripts/fetch_wiki.py --lang en --page "List of chemical elements" --elements-from data/tables.json
+   ```
+   This step downloads REST summaries for every element listed in `data/tables.json` and aggregates them into
+   `data/elements.json` (raw responses are saved under `data/raw/elements/`).
+4. Build the cover SVG and rasterize it:
    ```bash
    python scripts/build_cover_svg.py
    python scripts/rasterize_cover.py --width 1600 --height 2560 --out book/dist/cover_2560x1600.jpg
    ```
-4. Generate TASL attribution (required before assembling the EPUB):
+5. Generate TASL attribution (required before assembling the EPUB):
    ```bash
    python scripts/license_attribution.py
    ```
-5. Assemble the EPUB package:
+6. Assemble the EPUB package:
    ```bash
    python scripts/build_epub.py
    ```

--- a/notebooks/colab_build.ipynb
+++ b/notebooks/colab_build.ipynb
@@ -7,12 +7,13 @@
     "id": "overview"
    },
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pun2beam/makePeriodicTableEPUB/blob/main/notebooks/colab_build.ipynb)\n",
-    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pun2beam/makePeriodicTableEPUB/blob/main/notebooks/colab_build.ipynb)\n\n",
     "# Periodic Table EPUB build (Colab)\n",
     "This notebook reproduces the full EPUB build pipeline described in [`spec.md`](../spec.md) using Google Colab's default Python runtime.\n",
     "**Usage notes**:\n",
-    "- Open this notebook in Google Colab (File → Open notebook → GitHub).- (Optional) Connect your Google Drive if you want to persist the generated EPUB/cover files.- Run the cells from top to bottom; the pipeline will download the latest Wikipedia data, normalize it, build the SVG cover, rasterize it, and assemble the EPUB package inside `book/dist/`."
+    "- Open this notebook in Google Colab (File → Open notebook → GitHub).\n",
+    "- (Optional) Connect your Google Drive if you want to persist the generated EPUB/cover files.\n",
+    "- Run the cells from top to bottom; the pipeline will download the latest Wikipedia data, normalize it, fetch per-element summaries, build the SVG cover, rasterize it, and assemble the EPUB package inside `book/dist/`.\n"
    ]
   },
   {
@@ -79,8 +80,9 @@
    "outputs": [],
    "source": [
     "#@title Run data fetch, normalization, and build scripts\n",
-    "!python scripts/fetch_wiki.py --lang en --page \"Periodic table\"\n",
+    "!python scripts/fetch_wiki.py --lang en --page \"List of chemical elements\"\n",
     "!python scripts/normalize.py\n",
+    "!python scripts/fetch_wiki.py --lang en --page \"List of chemical elements\" --elements-from data/tables.json --elements-json data/elements.en.json\n",
     "!python scripts/build_cover_svg.py --in data/tables.json --out assets/gen/cover.svg\n",
     "!python scripts/license_attribution.py --out book/OEBPS/attribution.xhtml\n",
     "!python scripts/rasterize_cover.py --in assets/gen/cover.svg --out book/dist/cover_2560x1600.jpg --width 1600 --height 2560\n",


### PR DESCRIPTION
## Summary
- update the Colab build notebook to fetch from the "List of chemical elements" base page for both table and per-element data pulls

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d22c5039ac833181e7c3adc6aeeeee