### PR TITLE
Allow build_cover_svg to accept --in alias

### DIFF
--- a/scripts/build_cover_svg.py
+++ b/scripts/build_cover_svg.py
@@ -100,7 +100,14 @@ def render_svg(template_path: Path, cells: List[Cell]) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data", type=Path, default=Path("data/tables.json"), help="Normalized data JSON")
+    parser.add_argument(
+        "--data",
+        "--in",
+        dest="data",
+        type=Path,
+        default=Path("data/tables.json"),
+        help="Normalized data JSON",
+    )
     parser.add_argument("--template", type=Path, default=Path("assets/templates/cover.svg.j2"))
     parser.add_argument("--out", type=Path, default=Path("assets/gen/cover.svg"))
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- allow build_cover_svg.py to accept the documented --in argument as an alias for --data

## Testing
- python scripts/build_cover_svg.py --in data/tables.json --out /tmp/test.svg

------
https://chatgpt.com/codex/tasks/task_e_68d23364b7e48331a6313eb9445ecafc