### PR TITLE
Document passing element data to EPUB build

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ pip install -r requirements.txt
    ```bash
    python scripts/normalize.py
    ```
-3. Fetch per-element summaries using the normalized table:
+3. Fetch per-element summaries using the normalized table and write them to a language-specific file:
    ```bash
-   python scripts/fetch_wiki.py --lang en --page "List of chemical elements" --elements-from data/tables.json
+   python scripts/fetch_wiki.py --lang en --page "List of chemical elements" --elements-from data/tables.json --elements-json data/elements.en.json
    ```
    This step downloads REST summaries for every element listed in `data/tables.json` and aggregates them into
-   `data/elements.json` (raw responses are saved under `data/raw/elements/`).
+   `data/elements.en.json` (raw responses are saved under `data/raw/elements/`).
 4. Build the cover SVG and rasterize it:
    ```bash
    python scripts/build_cover_svg.py
@@ -40,9 +40,9 @@ pip install -r requirements.txt
    ```bash
    python scripts/license_attribution.py
    ```
-6. Assemble the EPUB package:
+6. Assemble the EPUB package (pass the per-element summaries so the detailed pages are included):
    ```bash
-   python scripts/build_epub.py
+   python scripts/build_epub.py --element-data data/elements.en.json
    ```
 
 The final files are written to `book/dist/`:

--- a/notebooks/colab_build.ipynb
+++ b/notebooks/colab_build.ipynb
@@ -1,133 +1,133 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "e715adef",
-   "metadata": {
-    "id": "overview"
-   },
-   "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pun2beam/makePeriodicTableEPUB/blob/main/notebooks/colab_build.ipynb)\n\n",
-    "# Periodic Table EPUB build (Colab)\n",
-    "This notebook reproduces the full EPUB build pipeline described in [`spec.md`](../spec.md) using Google Colab's default Python runtime.\n",
-    "**Usage notes**:\n",
-    "- Open this notebook in Google Colab (File → Open notebook → GitHub).\n",
-    "- (Optional) Connect your Google Drive if you want to persist the generated EPUB/cover files.\n",
-    "- Run the cells from top to bottom; the pipeline will download the latest Wikipedia data, normalize it, fetch per-element summaries, build the SVG cover, rasterize it, and assemble the EPUB package inside `book/dist/`.\n"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "e715adef",
+      "metadata": {
+        "id": "overview"
+      },
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pun2beam/makePeriodicTableEPUB/blob/main/notebooks/colab_build.ipynb)\n\n",
+        "# Periodic Table EPUB build (Colab)\n",
+        "This notebook reproduces the full EPUB build pipeline described in [`spec.md`](../spec.md) using Google Colab's default Python runtime.\n",
+        "**Usage notes**:\n",
+        "- Open this notebook in Google Colab (File → Open notebook → GitHub).\n",
+        "- (Optional) Connect your Google Drive if you want to persist the generated EPUB/cover files.\n",
+        "- Run the cells from top to bottom; the pipeline will download the latest Wikipedia data, normalize it, fetch per-element summaries, build the SVG cover, rasterize it, and assemble the EPUB package inside `book/dist/`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "de0b8165",
+      "metadata": {
+        "id": "pip-install",
+        "tags": [
+          "parameters"
+        ]
+      },
+      "outputs": [],
+      "source": [
+        "#@title Install Python dependencies\n",
+        "!git clone https://github.com/pun2beam/makePeriodicTableEPUB.git\n",
+        "%cd makePeriodicTableEPUB\n",
+        "!pip install --quiet -r requirements.txt"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "39314563",
+      "metadata": {
+        "id": "env-notes"
+      },
+      "source": [
+        "## Optional: Mount Google Drive\n",
+        "Uncomment the cell below if you want the generated assets to be saved to Google Drive instead of the Colab ephemeral filesystem."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "28a48dcc",
+      "metadata": {
+        "id": "drive-mount"
+      },
+      "outputs": [],
+      "source": [
+        "# from google.colab import drive\n",
+        "# drive.mount('/content/drive')\n",
+        "# %cd /content/drive/MyDrive/path/to/your/workdir"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "51a46bd9",
+      "metadata": {
+        "id": "pipeline"
+      },
+      "source": [
+        "## Build the EPUB\n",
+        "The commands below follow the workflow defined in Section 4 of the specification. They can be rerun to refresh the data or rebuild the package after modifying templates or scripts."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "6733a2de",
+      "metadata": {
+        "id": "run-pipeline"
+      },
+      "outputs": [],
+      "source": [
+        "#@title Run data fetch, normalization, and build scripts\n",
+        "!python scripts/fetch_wiki.py --lang en --page \"List of chemical elements\"\n",
+        "!python scripts/normalize.py\n",
+        "!python scripts/fetch_wiki.py --lang en --page \"List of chemical elements\" --elements-from data/tables.json --elements-json data/elements.en.json\n",
+        "!python scripts/build_cover_svg.py --in data/tables.json --out assets/gen/cover.svg\n",
+        "!python scripts/license_attribution.py --out book/OEBPS/attribution.xhtml\n",
+        "!python scripts/rasterize_cover.py --in assets/gen/cover.svg --out book/dist/cover_2560x1600.jpg --width 1600 --height 2560\n",
+        "!python scripts/build_epub.py --cover book/dist/cover_2560x1600.jpg --out book/dist/PeriodicTable.en.epub --element-data data/elements.en.json\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e6e5dd14",
+      "metadata": {
+        "id": "inspect"
+      },
+      "source": [
+        "## Inspect generated files\n",
+        "Run the following cell to list the distribution folder and confirm that the EPUB and cover JPEG were produced successfully."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "2509c2e8",
+      "metadata": {
+        "id": "list-dist"
+      },
+      "outputs": [],
+      "source": [
+        "#@title Check build outputs\n",
+        "!ls -lh book/dist"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "colab_build.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "de0b8165",
-   "metadata": {
-    "id": "pip-install",
-    "tags": [
-     "parameters"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "#@title Install Python dependencies\n",
-    "!git clone https://github.com/pun2beam/makePeriodicTableEPUB.git\n",
-    "%cd makePeriodicTableEPUB\n",
-    "!pip install --quiet -r requirements.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "39314563",
-   "metadata": {
-    "id": "env-notes"
-   },
-   "source": [
-    "## Optional: Mount Google Drive\n",
-    "Uncomment the cell below if you want the generated assets to be saved to Google Drive instead of the Colab ephemeral filesystem."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "28a48dcc",
-   "metadata": {
-    "id": "drive-mount"
-   },
-   "outputs": [],
-   "source": [
-    "# from google.colab import drive\n",
-    "# drive.mount('/content/drive')\n",
-    "# %cd /content/drive/MyDrive/path/to/your/workdir"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "51a46bd9",
-   "metadata": {
-    "id": "pipeline"
-   },
-   "source": [
-    "## Build the EPUB\n",
-    "The commands below follow the workflow defined in Section 4 of the specification. They can be rerun to refresh the data or rebuild the package after modifying templates or scripts."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6733a2de",
-   "metadata": {
-    "id": "run-pipeline"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Run data fetch, normalization, and build scripts\n",
-    "!python scripts/fetch_wiki.py --lang en --page \"List of chemical elements\"\n",
-    "!python scripts/normalize.py\n",
-    "!python scripts/fetch_wiki.py --lang en --page \"List of chemical elements\" --elements-from data/tables.json --elements-json data/elements.en.json\n",
-    "!python scripts/build_cover_svg.py --in data/tables.json --out assets/gen/cover.svg\n",
-    "!python scripts/license_attribution.py --out book/OEBPS/attribution.xhtml\n",
-    "!python scripts/rasterize_cover.py --in assets/gen/cover.svg --out book/dist/cover_2560x1600.jpg --width 1600 --height 2560\n",
-    "!python scripts/build_epub.py --cover book/dist/cover_2560x1600.jpg --out book/dist/PeriodicTable.en.epub\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e6e5dd14",
-   "metadata": {
-    "id": "inspect"
-   },
-   "source": [
-    "## Inspect generated files\n",
-    "Run the following cell to list the distribution folder and confirm that the EPUB and cover JPEG were produced successfully."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2509c2e8",
-   "metadata": {
-    "id": "list-dist"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Check build outputs\n",
-    "!ls -lh book/dist"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "name": "colab_build.ipynb",
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- clarify that per-element summaries should be written to a language-specific JSON file
- document passing the language-specific summaries to the EPUB build script in both the README and Colab notebook

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d235d3c9588331a6f4ebf08c01e61c