### PR TITLE
Format element metadata as table

### DIFF
--- a/book/OEBPS/css/style.css
+++ b/book/OEBPS/css/style.css
@@ -18,10 +18,36 @@ table {
   margin-bottom: 1.5em;
 }
 
-td, th {
+td,
+th {
   border: 1px solid #000;
   padding: 0.4em;
   text-align: center;
+}
+
+.element-meta {
+  margin-bottom: 1.5em;
+}
+
+.element-meta th {
+  text-align: left;
+  width: 45%;
+}
+
+.element-meta td {
+  text-align: left;
+}
+
+.element-meta-extra {
+  margin-bottom: 1.5em;
+}
+
+.element-meta-extra dt {
+  font-weight: 700;
+}
+
+.element-meta-extra dd {
+  margin: 0 0 0.4em 0;
 }
 
 .periodic-grid {

--- a/scripts/build_epub.py
+++ b/scripts/build_epub.py
@@ -23,24 +23,40 @@ def render_element_page(element: Dict[str, object]) -> str:
     description = element.get("description")
     subtitle = f"<p class=\"subtitle\">{escape(str(description))}</p>" if description else ""
 
-    info_pairs = [
+    table_fields = [
         ("Atomic number", element.get("atomic_number")),
         ("Symbol", symbol),
-        ("Standard atomic weight", element.get("standard_atomic_weight")),
         ("Group", element.get("group")),
         ("Period", element.get("period")),
         ("Block", element.get("block_label") or element.get("block")),
         ("Category", element.get("category")),
         ("Phase (STP)", element.get("phase")),
-        ("Origin", element.get("origin")),
     ]
-    info_html = "".join(
-        f"<dt>{escape(str(label))}</dt><dd>{escape(str(value))}</dd>"
-        for label, value in info_pairs
+    table_rows = "".join(
+        "<tr><th scope=\"row\">{label}</th><td>{value}</td></tr>".format(
+            label=escape(str(label)),
+            value=escape(str(value)),
+        )
+        for label, value in table_fields
         if value not in (None, "")
     )
-    if info_html:
-        info_html = f"<dl class=\"element-meta\">{info_html}</dl>"
+    table_html = (
+        f"<table class=\"element-meta\"><tbody>{table_rows}</tbody></table>"
+        if table_rows
+        else ""
+    )
+
+    additional_pairs = [
+        ("Standard atomic weight", element.get("standard_atomic_weight")),
+        ("Origin", element.get("origin")),
+    ]
+    additional_html = "".join(
+        f"<dt>{escape(str(label))}</dt><dd>{escape(str(value))}</dd>"
+        for label, value in additional_pairs
+        if value not in (None, "")
+    )
+    if additional_html:
+        additional_html = f"<dl class=\"element-meta-extra\">{additional_html}</dl>"
 
     summary_html = element.get("summary_html")
     if summary_html:
@@ -76,7 +92,7 @@ def render_element_page(element: Dict[str, object]) -> str:
         "</title><link rel=\"stylesheet\" href=\"../css/style.css\" type=\"text/css\"/></head>"
         "<body>"
         f"<h1>{escape(name)} ({escape(str(symbol))})</h1>"
-        f"{subtitle}{info_html}{summary_section}{source_html}"
+        f"{subtitle}{table_html}{additional_html}{summary_section}{source_html}"
         "</body></html>"
     )
 


### PR DESCRIPTION
## Summary
- Render key element metadata fields as a two-column table on each element page.
- Preserve additional metadata and update CSS styling to support the new layout.

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68d265fe439c83318046b87494a4b1c7