### PR TITLE
Add standard atomic weight to element metadata table

### DIFF
--- a/scripts/build_epub.py
+++ b/scripts/build_epub.py
@@ -26,6 +26,7 @@ def render_element_page(element: Dict[str, object]) -> str:
     table_fields = [
         ("Atomic number", element.get("atomic_number")),
         ("Symbol", symbol),
+        ("Standard atomic weight", element.get("standard_atomic_weight")),
         ("Group", element.get("group")),
         ("Period", element.get("period")),
         ("Block", element.get("block_label") or element.get("block")),
@@ -47,7 +48,6 @@ def render_element_page(element: Dict[str, object]) -> str:
     )
 
     additional_pairs = [
-        ("Standard atomic weight", element.get("standard_atomic_weight")),
         ("Origin", element.get("origin")),
     ]
     additional_html = "".join(


### PR DESCRIPTION
## Summary
- include the standard atomic weight in the element metadata table rows
- keep the extra metadata list focused on origin information only

## Testing
- python -m compileall scripts/build_epub.py

------
https://chatgpt.com/codex/tasks/task_e_68d27656df988331b5b4470a22a49e2d