### PR TITLE
Fix missing xlink namespace in cover SVG

### DIFF
--- a/assets/gen/cover.svg
+++ b/assets/gen/cover.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="2560" viewBox="0 0 1600 2560">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1600" height="2560" viewBox="0 0 1600 2560">
   <style>
     text { font-family: 'DejaVu Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; }
     .title { font-size: 72px; font-weight: 700; letter-spacing: 4px; text-anchor: middle; }

--- a/assets/templates/cover.svg.j2
+++ b/assets/templates/cover.svg.j2
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="{{ cover_width }}" height="{{ cover_height }}" viewBox="0 0 {{ cover_width }} {{ cover_height }}">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{ cover_width }}" height="{{ cover_height }}" viewBox="0 0 {{ cover_width }} {{ cover_height }}">
   <style>
     text { font-family: 'DejaVu Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; }
     .title { font-size: 72px; font-weight: 700; letter-spacing: 4px; text-anchor: middle; }


### PR DESCRIPTION
## Summary
- add the xlink namespace declaration to the cover SVG template so generated files bind the prefix

## Testing
- python scripts/build_cover_svg.py
- python scripts/rasterize_cover.py --width 1600 --height 2560 --out book/dist/cover_2560x1600.jpg

------
https://chatgpt.com/codex/tasks/task_e_68d290e60c608331998e96e3ee3cc9a3