### PR TITLE
Adjust cover font stack to prefer Latin fonts

### DIFF
--- a/assets/templates/cover.svg.j2
+++ b/assets/templates/cover.svg.j2
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{ cover_width }}" height="{{ cover_height }}" viewBox="0 0 {{ cover_width }} {{ cover_height }}">
   <style>
-    text { font-family: 'DejaVu Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; }
+    text { font-family: 'Helvetica Neue', Helvetica, Arial, 'Noto Sans', 'DejaVu Sans', 'Noto Sans CJK JP', 'Noto Sans JP', sans-serif; }
     .title { font-size: 72px; font-weight: 700; letter-spacing: 4px; text-anchor: middle; }
     .subtitle { font-size: 36px; font-weight: 400; text-anchor: middle; }
     .cell { fill: #fdfdfd; stroke: #000; stroke-width: 2; }

--- a/notebooks/colab_build.ipynb
+++ b/notebooks/colab_build.ipynb
@@ -1,133 +1,147 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "e715adef",
-      "metadata": {
-        "id": "overview"
-      },
-      "source": [
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pun2beam/makePeriodicTableEPUB/blob/main/notebooks/colab_build.ipynb)\n\n",
-        "# Periodic Table EPUB build (Colab)\n",
-        "This notebook reproduces the full EPUB build pipeline described in [`spec.md`](../spec.md) using Google Colab's default Python runtime.\n",
-        "**Usage notes**:\n",
-        "- Open this notebook in Google Colab (File → Open notebook → GitHub).\n",
-        "- (Optional) Connect your Google Drive if you want to persist the generated EPUB/cover files.\n",
-        "- Run the cells from top to bottom; the pipeline will download the latest Wikipedia data, normalize it, fetch per-element summaries, build the SVG cover, rasterize it, and assemble the EPUB package inside `book/dist/`.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "de0b8165",
-      "metadata": {
-        "id": "pip-install",
-        "tags": [
-          "parameters"
-        ]
-      },
-      "outputs": [],
-      "source": [
-        "#@title Install Python dependencies\n",
-        "!git clone https://github.com/pun2beam/makePeriodicTableEPUB.git\n",
-        "%cd makePeriodicTableEPUB\n",
-        "!pip install --quiet -r requirements.txt"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "39314563",
-      "metadata": {
-        "id": "env-notes"
-      },
-      "source": [
-        "## Optional: Mount Google Drive\n",
-        "Uncomment the cell below if you want the generated assets to be saved to Google Drive instead of the Colab ephemeral filesystem."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "28a48dcc",
-      "metadata": {
-        "id": "drive-mount"
-      },
-      "outputs": [],
-      "source": [
-        "# from google.colab import drive\n",
-        "# drive.mount('/content/drive')\n",
-        "# %cd /content/drive/MyDrive/path/to/your/workdir"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "51a46bd9",
-      "metadata": {
-        "id": "pipeline"
-      },
-      "source": [
-        "## Build the EPUB\n",
-        "The commands below follow the workflow defined in Section 4 of the specification. They can be rerun to refresh the data or rebuild the package after modifying templates or scripts."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6733a2de",
-      "metadata": {
-        "id": "run-pipeline"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Run data fetch, normalization, and build scripts\n",
-        "!python scripts/fetch_wiki.py --lang en --page \"List of chemical elements\"\n",
-        "!python scripts/normalize.py\n",
-        "!python scripts/fetch_wiki.py --lang en --page \"List of chemical elements\" --elements-from data/tables.json --elements-json data/elements.en.json\n",
-        "!python scripts/build_cover_svg.py --in data/tables.json --out assets/gen/cover.svg\n",
-        "!python scripts/license_attribution.py --out book/OEBPS/attribution.xhtml\n",
-        "!python scripts/rasterize_cover.py --in assets/gen/cover.svg --out book/dist/cover_2560x1600.jpg --width 1600 --height 2560\n",
-        "!python scripts/build_epub.py --cover book/dist/cover_2560x1600.jpg --out book/dist/PeriodicTable.en.epub --element-data data/elements.en.json\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e6e5dd14",
-      "metadata": {
-        "id": "inspect"
-      },
-      "source": [
-        "## Inspect generated files\n",
-        "Run the following cell to list the distribution folder and confirm that the EPUB and cover JPEG were produced successfully."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "2509c2e8",
-      "metadata": {
-        "id": "list-dist"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Check build outputs\n",
-        "!ls -lh book/dist"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "colab_build.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e715adef",
+   "metadata": {
+    "id": "overview"
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pun2beam/makePeriodicTableEPUB/blob/main/notebooks/colab_build.ipynb)\n\n",
+    "# Periodic Table EPUB build (Colab)\n",
+    "This notebook reproduces the full EPUB build pipeline described in [`spec.md`](../spec.md) using Google Colab's default Python runtime.\n",
+    "**Usage notes**:\n",
+    "- Open this notebook in Google Colab (File → Open notebook → GitHub).\n",
+    "- (Optional) Connect your Google Drive if you want to persist the generated EPUB/cover files.\n",
+    "- Run the cells from top to bottom; the pipeline will download the latest Wikipedia data, normalize it, fetch per-element summaries, build the SVG cover, rasterize it, and assemble the EPUB package inside `book/dist/`.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de0b8165",
+   "metadata": {
+    "id": "pip-install",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "#@title Install Python dependencies\n",
+    "!git clone https://github.com/pun2beam/makePeriodicTableEPUB.git\n",
+    "%cd makePeriodicTableEPUB\n",
+    "!pip install --quiet -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_fonts"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Install system fonts for Japanese text\n",
+    "!apt-get update -y\n",
+    "!apt-get install -y fonts-noto-cjk\n",
+    "!fc-cache -fv\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39314563",
+   "metadata": {
+    "id": "env-notes"
+   },
+   "source": [
+    "## Optional: Mount Google Drive\n",
+    "Uncomment the cell below if you want the generated assets to be saved to Google Drive instead of the Colab ephemeral filesystem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28a48dcc",
+   "metadata": {
+    "id": "drive-mount"
+   },
+   "outputs": [],
+   "source": [
+    "# from google.colab import drive\n",
+    "# drive.mount('/content/drive')\n",
+    "# %cd /content/drive/MyDrive/path/to/your/workdir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51a46bd9",
+   "metadata": {
+    "id": "pipeline"
+   },
+   "source": [
+    "## Build the EPUB\n",
+    "The commands below follow the workflow defined in Section 4 of the specification. They can be rerun to refresh the data or rebuild the package after modifying templates or scripts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6733a2de",
+   "metadata": {
+    "id": "run-pipeline"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Run data fetch, normalization, and build scripts\n",
+    "!python scripts/fetch_wiki.py --lang en --page \"List of chemical elements\"\n",
+    "!python scripts/normalize.py\n",
+    "!python scripts/fetch_wiki.py --lang en --page \"List of chemical elements\" --elements-from data/tables.json --elements-json data/elements.en.json\n",
+    "!python scripts/build_cover_svg.py --in data/tables.json --out assets/gen/cover.svg\n",
+    "!python scripts/license_attribution.py --out book/OEBPS/attribution.xhtml\n",
+    "!python scripts/rasterize_cover.py --in assets/gen/cover.svg --out book/dist/cover_2560x1600.jpg --width 1600 --height 2560\n",
+    "!python scripts/build_epub.py --cover book/dist/cover_2560x1600.jpg --out book/dist/PeriodicTable.en.epub --element-data data/elements.en.json\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6e5dd14",
+   "metadata": {
+    "id": "inspect"
+   },
+   "source": [
+    "## Inspect generated files\n",
+    "Run the following cell to list the distribution folder and confirm that the EPUB and cover JPEG were produced successfully."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2509c2e8",
+   "metadata": {
+    "id": "list-dist"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Check build outputs\n",
+    "!ls -lh book/dist"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "colab_build.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- reorder the cover SVG font stack so Latin UI fonts remain first choice
- keep Japanese-capable Noto CJK fonts as fallbacks when glyphs are missing

## Testing
- python scripts/rasterize_cover.py --in assets/gen/cover.svg --out /tmp/cover.jpg --width 1600 --height 2560

------
https://chatgpt.com/codex/tasks/task_e_68d2c70f52b083319dac620021939e77