### PR TITLE
Allow comma-separated bracketed weights

### DIFF
--- a/scripts/normalize.py
+++ b/scripts/normalize.py
@@ -64,7 +64,7 @@ def clean_text(value: Any, *, preserve_bracket_values: bool = False) -> str:
     text = str(value)
     def _replace(match: re.Match[str]) -> str:
         inner = match.group(1)
-        if preserve_bracket_values and re.fullmatch(r"\s*[\d.–-]+\s*", inner or ""):
+        if preserve_bracket_values and re.fullmatch(r"\s*[\d.,–-]+\s*", inner or ""):
             return match.group(0)
         return ""
 


### PR DESCRIPTION
## Summary
- permit standard atomic weight values with commas inside brackets to be preserved during cleaning

## Testing
- python -m compileall scripts/normalize.py

------
https://chatgpt.com/codex/tasks/task_e_68d2d2e616788331a2e8bc67b0eefe57