### PR TITLE
Update documentation samples to show explicit raw output filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pip install -r requirements.txt
 
 1. Fetch Wikipedia data (defaults to the English "List of chemical elements" page):
    ```bash
-   python scripts/fetch_wiki.py --lang en --page "List of chemical elements"
+   python scripts/fetch_wiki.py --lang en --page "List of chemical elements" --output-file list-of-chemical-elements-en-rest.json
    ```
    Add `--log-level DEBUG` to see detailed progress information or `--log-file logs/wiki-fetch.log`
    to also persist the log to disk.

--- a/notebooks/colab_build.ipynb
+++ b/notebooks/colab_build.ipynb
@@ -1,552 +1,552 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "e715adef",
-      "metadata": {
-        "id": "e715adef"
-      },
-      "source": [
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pun2beam/makePeriodicTableEPUB/blob/main/notebooks/colab_build.ipynb)\n",
-        "\n",
-        "# Periodic Table EPUB build (Colab)\n",
-        "This notebook reproduces the full EPUB build pipeline described in [`spec.md`](../spec.md) using Google Colab's default Python runtime.\n",
-        "**Usage notes**:\n",
-        "- Open this notebook in Google Colab (File → Open notebook → GitHub).\n",
-        "- (Optional) Connect your Google Drive if you want to persist the generated EPUB/cover files.\n",
-        "- Run the cells from top to bottom; the pipeline will download the latest Wikipedia data, normalize it, fetch per-element summaries, build the SVG cover, rasterize it, and assemble the EPUB package inside `book/dist/`.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "id": "de0b8165",
-      "metadata": {
-        "id": "de0b8165",
-        "tags": [
-          "parameters"
-        ],
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "afac3174-b6bc-4215-d638-f1a26d864c82"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Cloning into 'makePeriodicTableEPUB'...\n",
-            "remote: Enumerating objects: 365, done.\u001b[K\n",
-            "remote: Counting objects: 100% (37/37), done.\u001b[K\n",
-            "remote: Compressing objects: 100% (37/37), done.\u001b[K\n",
-            "remote: Total 365 (delta 11), reused 0 (delta 0), pack-reused 328 (from 2)\u001b[K\n",
-            "Receiving objects: 100% (365/365), 469.62 KiB | 3.24 MiB/s, done.\n",
-            "Resolving deltas: 100% (189/189), done.\n",
-            "/content/makePeriodicTableEPUB\n"
-          ]
-        }
-      ],
-      "source": [
-        "#@title Install Python dependencies\n",
-        "%cd /content/\n",
-        "!git clone https://github.com/pun2beam/makePeriodicTableEPUB.git\n",
-        "%cd /content/makePeriodicTableEPUB\n",
-        "!pip install --quiet -r requirements.txt"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#@title Install system fonts for Japanese text\n",
-        "!apt-get update -y\n",
-        "!apt-get install -y fonts-noto-cjk\n",
-        "!fc-cache -fv\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "6E0qDnzAZUId",
-        "outputId": "9a094183-91bf-42ad-eb70-c1d7315f51a2"
-      },
-      "id": "6E0qDnzAZUId",
-      "execution_count": 8,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\r0% [Working]\r            \rHit:1 https://cli.github.com/packages stable InRelease\n",
-            "\r0% [Connecting to archive.ubuntu.com (185.125.190.82)] [Waiting for headers] [W\r                                                                               \rGet:2 https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/ InRelease [3,632 B]\n",
-            "\r0% [Connecting to archive.ubuntu.com (185.125.190.82)] [Waiting for headers] [C\r                                                                               \rHit:3 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64  InRelease\n",
-            "Hit:4 http://security.ubuntu.com/ubuntu jammy-security InRelease\n",
-            "Hit:5 http://archive.ubuntu.com/ubuntu jammy InRelease\n",
-            "Hit:6 https://r2u.stat.illinois.edu/ubuntu jammy InRelease\n",
-            "Hit:7 http://archive.ubuntu.com/ubuntu jammy-updates InRelease\n",
-            "Hit:8 http://archive.ubuntu.com/ubuntu jammy-backports InRelease\n",
-            "Hit:9 https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy InRelease\n",
-            "Hit:10 https://ppa.launchpadcontent.net/graphics-drivers/ppa/ubuntu jammy InRelease\n",
-            "Hit:11 https://ppa.launchpadcontent.net/ubuntugis/ppa/ubuntu jammy InRelease\n",
-            "Fetched 3,632 B in 1s (2,929 B/s)\n",
-            "Reading package lists... Done\n",
-            "W: Skipping acquire of configured file 'main/source/Sources' as repository 'https://r2u.stat.illinois.edu/ubuntu jammy InRelease' does not seem to provide it (sources.list entry misspelt?)\n",
-            "Reading package lists... Done\n",
-            "Building dependency tree... Done\n",
-            "Reading state information... Done\n",
-            "fonts-noto-cjk is already the newest version (1:20220127+repack1-1).\n",
-            "0 upgraded, 0 newly installed, 0 to remove and 43 not upgraded.\n",
-            "/usr/share/fonts: caching, new cache contents: 0 fonts, 2 dirs\n",
-            "/usr/share/fonts/opentype: caching, new cache contents: 0 fonts, 1 dirs\n",
-            "/usr/share/fonts/opentype/noto: caching, new cache contents: 30 fonts, 0 dirs\n",
-            "/usr/share/fonts/truetype: caching, new cache contents: 0 fonts, 2 dirs\n",
-            "/usr/share/fonts/truetype/humor-sans: caching, new cache contents: 1 fonts, 0 dirs\n",
-            "/usr/share/fonts/truetype/liberation: caching, new cache contents: 16 fonts, 0 dirs\n",
-            "/usr/local/share/fonts: caching, new cache contents: 0 fonts, 0 dirs\n",
-            "/root/.local/share/fonts: skipping, no such directory\n",
-            "/root/.fonts: skipping, no such directory\n",
-            "/usr/share/fonts/opentype: skipping, looped directory detected\n",
-            "/usr/share/fonts/truetype: skipping, looped directory detected\n",
-            "/usr/share/fonts/opentype/noto: skipping, looped directory detected\n",
-            "/usr/share/fonts/truetype/humor-sans: skipping, looped directory detected\n",
-            "/usr/share/fonts/truetype/liberation: skipping, looped directory detected\n",
-            "/var/cache/fontconfig: cleaning cache directory\n",
-            "/root/.cache/fontconfig: not cleaning non-existent cache directory\n",
-            "/root/.fontconfig: not cleaning non-existent cache directory\n",
-            "fc-cache: succeeded\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "%cd /content/makePeriodicTableEPUB\n",
-        "!git pull"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "lyQ1nNVPqNpx",
-        "outputId": "4a81e99d-04eb-4f14-9ec1-e600d3c4b7e1"
-      },
-      "id": "lyQ1nNVPqNpx",
-      "execution_count": 20,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "/content/makePeriodicTableEPUB\n",
-            "remote: Enumerating objects: 5, done.\u001b[K\n",
-            "remote: Counting objects: 100% (5/5), done.\u001b[K\n",
-            "remote: Compressing objects: 100% (5/5), done.\u001b[K\n",
-            "remote: Total 5 (delta 1), reused 0 (delta 0), pack-reused 0 (from 0)\u001b[K\n",
-            "Unpacking objects: 100% (5/5), 6.02 KiB | 3.01 MiB/s, done.\n",
-            "From https://github.com/pun2beam/makePeriodicTableEPUB\n",
-            "   0b0e4ea..838a552  main       -> origin/main\n",
-            " * [new branch]      codex/fix-metadata-language-error-in-epub -> origin/codex/fix-metadata-language-error-in-epub\n",
-            "Updating 0b0e4ea..838a552\n",
-            "Fast-forward\n",
-            " scripts/build_epub.py | 29 \u001b[32m++++++++++++++++++++++++++++\u001b[m\u001b[31m-\u001b[m\n",
-            " 1 file changed, 28 insertions(+), 1 deletion(-)\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "39314563",
-      "metadata": {
-        "id": "39314563"
-      },
-      "source": [
-        "## Optional: Mount Google Drive\n",
-        "Uncomment the cell below if you want the generated assets to be saved to Google Drive instead of the Colab ephemeral filesystem."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "id": "28a48dcc",
-      "metadata": {
-        "id": "28a48dcc"
-      },
-      "outputs": [],
-      "source": [
-        "# from google.colab import drive\n",
-        "# drive.mount('/content/drive')\n",
-        "# %cd /content/drive/MyDrive/path/to/your/workdir"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "51a46bd9",
-      "metadata": {
-        "id": "51a46bd9"
-      },
-      "source": [
-        "## Build the EPUB\n",
-        "The commands below follow the workflow defined in Section 4 of the specification. They can be rerun to refresh the data or rebuild the package after modifying templates or scripts."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "WAKr7eeO80Q6"
-      },
-      "id": "WAKr7eeO80Q6",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 24,
-      "id": "6733a2de",
-      "metadata": {
-        "id": "6733a2de",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "73ba6b99-c53a-4099-aa38-e2699b009f98"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "2025-09-23 19:02:12,322 INFO __main__: Starting fetch\n",
-            "2025-09-23 19:02:12,707 INFO __main__: Fetched REST API page html\n",
-            "2025-09-23 19:02:12,712 INFO __main__: Saved raw data\n",
-            "Wrote normalized data to data/tables.json\n",
-            "2025-09-23 19:02:14,135 INFO __main__: Starting fetch\n",
-            "2025-09-23 19:02:14,356 INFO __main__: Fetched REST API page html\n",
-            "2025-09-23 19:02:14,361 INFO __main__: Saved raw data\n",
-            "2025-09-23 19:02:14,431 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:14,432 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:14,499 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:14,500 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:14,567 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:14,568 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:14,633 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:14,634 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:14,702 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:14,703 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:14,768 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:14,769 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:14,839 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:14,840 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:14,905 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:14,906 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:14,973 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:14,974 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,040 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,041 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,112 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,113 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,184 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,185 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,256 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,257 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,327 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,329 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,402 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,403 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,474 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,475 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,544 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,545 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,612 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,613 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,682 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,684 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,752 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,753 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,822 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,823 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,890 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,891 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:15,963 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:15,964 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,035 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,036 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,105 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,106 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,175 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,176 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,244 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,246 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,318 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,320 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,395 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,396 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,468 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,469 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,537 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,539 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,612 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,613 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,686 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,687 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,759 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,760 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,831 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,832 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,902 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,904 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:16,973 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:16,974 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,041 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,042 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,110 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,111 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,179 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,180 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,246 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,247 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,315 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,315 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,382 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,383 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,453 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,454 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,520 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,521 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,588 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,589 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,654 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,655 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,721 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,722 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,788 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,789 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,855 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,856 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,921 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,922 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:17,989 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:17,990 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,059 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,060 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,126 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,127 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,194 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,195 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,261 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,261 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,329 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,330 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,396 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,396 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,462 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,463 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,530 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,531 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,601 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,602 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,668 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,669 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,736 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,736 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,803 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,804 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,871 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,872 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:18,938 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:18,939 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,005 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,006 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,073 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,074 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,142 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,142 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,210 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,210 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,277 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,278 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,345 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,346 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,412 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,413 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,481 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,482 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,547 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,548 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,614 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,615 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,683 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,683 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,751 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,752 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,819 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,820 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,888 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,889 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:19,958 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:19,959 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,025 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,026 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,092 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,092 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,157 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,158 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,223 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,224 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,293 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,294 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,361 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,362 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,429 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,430 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,498 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,498 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,566 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,567 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,634 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,635 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,702 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,703 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,771 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,772 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,839 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,840 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,908 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,909 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:20,974 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:20,975 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,042 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,043 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,111 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,112 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,182 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,183 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,250 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,250 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,315 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,316 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,382 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,383 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,449 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,450 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,517 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,517 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,583 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,584 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,652 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,653 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,718 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,719 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,786 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,787 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,856 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,857 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,924 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,925 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:21,993 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:21,994 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:22,061 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:22,062 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:22,128 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:22,129 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:22,196 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:22,197 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:22,266 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:22,267 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:22,333 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:22,334 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:22,401 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:22,402 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:22,470 INFO __main__: Fetched REST API summary\n",
-            "2025-09-23 19:02:22,471 INFO __main__: Fetched element summary\n",
-            "2025-09-23 19:02:22,476 INFO __main__: Wrote element summaries\n",
-            "Wrote cover SVG to assets/gen/cover.svg\n",
-            "Wrote attribution XHTML to book/OEBPS/attribution.xhtml\n",
-            "Rasterized cover to book/dist/cover_2560x1600.jpg\n",
-            "Built EPUB at book/dist/PeriodicTable.ja.epub\n"
-          ]
-        }
-      ],
-      "source": [
-        "#@title Run data fetch, normalization, and build scripts\n",
-        "# !python scripts/fetch_wiki.py --lang en --page \"List of chemical elements\"\n",
-        "!python scripts/fetch_wiki.py --lang ja --page \"元素の一覧\"\n",
-        "# !python scripts/normalize.py\n",
-        "!python scripts/normalize.py --input data/raw/yuan-su-noyi-lan-ja-rest.json\n",
-        "!python scripts/fetch_wiki.py --lang ja --page \"元素の一覧\" --elements-from data/tables.json --elements-json data/elements.ja.json\n",
-        "!python scripts/build_cover_svg.py --in data/tables.json --out assets/gen/cover.svg\n",
-        "!python scripts/license_attribution.py --out book/OEBPS/attribution.xhtml\n",
-        "!python scripts/rasterize_cover.py --in assets/gen/cover.svg --out book/dist/cover_2560x1600.jpg --width 1600 --height 2560\n",
-        "# !python scripts/build_epub.py --cover book/dist/cover_2560x1600.jpg --out book/dist/PeriodicTable.en.epub --element-data data/elements.en.json\n",
-        "!python scripts/build_epub.py --cover book/dist/cover_2560x1600.jpg --out book/dist/PeriodicTable.ja.epub --element-data data/elements.ja.json\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e6e5dd14",
-      "metadata": {
-        "id": "e6e5dd14"
-      },
-      "source": [
-        "## Inspect generated files\n",
-        "Run the following cell to list the distribution folder and confirm that the EPUB and cover JPEG were produced successfully."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 16,
-      "id": "2509c2e8",
-      "metadata": {
-        "id": "2509c2e8",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "eee5e471-4db3-4d54-81bc-3980e03dee50"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "ls: cannot access 'book/dist': No such file or directory\n"
-          ]
-        }
-      ],
-      "source": [
-        "#@title Check build outputs\n",
-        "!ls -lh book/dist"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!rm -rf /content/makePeriodicTableEPUB/data\n",
-        "!rm -rf /content/makePeriodicTableEPUB/book/\n",
-        "!rm -rf /content/makePeriodicTableEPUB/makePeriodicTableEPUB/\n"
-      ],
-      "metadata": {
-        "id": "LAYSUhT0kMoQ"
-      },
-      "id": "LAYSUhT0kMoQ",
-      "execution_count": 23,
-      "outputs": []
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "colab_build.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e715adef",
+   "metadata": {
+    "id": "e715adef"
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pun2beam/makePeriodicTableEPUB/blob/main/notebooks/colab_build.ipynb)\n",
+    "\n",
+    "# Periodic Table EPUB build (Colab)\n",
+    "This notebook reproduces the full EPUB build pipeline described in [`spec.md`](../spec.md) using Google Colab's default Python runtime.\n",
+    "**Usage notes**:\n",
+    "- Open this notebook in Google Colab (File → Open notebook → GitHub).\n",
+    "- (Optional) Connect your Google Drive if you want to persist the generated EPUB/cover files.\n",
+    "- Run the cells from top to bottom; the pipeline will download the latest Wikipedia data, normalize it, fetch per-element summaries, build the SVG cover, rasterize it, and assemble the EPUB package inside `book/dist/`.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "de0b8165",
+   "metadata": {
+    "id": "de0b8165",
+    "tags": [
+     "parameters"
+    ],
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "outputId": "afac3174-b6bc-4215-d638-f1a26d864c82"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Cloning into 'makePeriodicTableEPUB'...\n",
+      "remote: Enumerating objects: 365, done.\u001b[K\n",
+      "remote: Counting objects: 100% (37/37), done.\u001b[K\n",
+      "remote: Compressing objects: 100% (37/37), done.\u001b[K\n",
+      "remote: Total 365 (delta 11), reused 0 (delta 0), pack-reused 328 (from 2)\u001b[K\n",
+      "Receiving objects: 100% (365/365), 469.62 KiB | 3.24 MiB/s, done.\n",
+      "Resolving deltas: 100% (189/189), done.\n",
+      "/content/makePeriodicTableEPUB\n"
+     ]
+    }
+   ],
+   "source": [
+    "#@title Install Python dependencies\n",
+    "%cd /content/\n",
+    "!git clone https://github.com/pun2beam/makePeriodicTableEPUB.git\n",
+    "%cd /content/makePeriodicTableEPUB\n",
+    "!pip install --quiet -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "#@title Install system fonts for Japanese text\n",
+    "!apt-get update -y\n",
+    "!apt-get install -y fonts-noto-cjk\n",
+    "!fc-cache -fv\n"
+   ],
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "6E0qDnzAZUId",
+    "outputId": "9a094183-91bf-42ad-eb70-c1d7315f51a2"
+   },
+   "id": "6E0qDnzAZUId",
+   "execution_count": 8,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\r0% [Working]\r            \rHit:1 https://cli.github.com/packages stable InRelease\n",
+      "\r0% [Connecting to archive.ubuntu.com (185.125.190.82)] [Waiting for headers] [W\r                                                                               \rGet:2 https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/ InRelease [3,632 B]\n",
+      "\r0% [Connecting to archive.ubuntu.com (185.125.190.82)] [Waiting for headers] [C\r                                                                               \rHit:3 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64  InRelease\n",
+      "Hit:4 http://security.ubuntu.com/ubuntu jammy-security InRelease\n",
+      "Hit:5 http://archive.ubuntu.com/ubuntu jammy InRelease\n",
+      "Hit:6 https://r2u.stat.illinois.edu/ubuntu jammy InRelease\n",
+      "Hit:7 http://archive.ubuntu.com/ubuntu jammy-updates InRelease\n",
+      "Hit:8 http://archive.ubuntu.com/ubuntu jammy-backports InRelease\n",
+      "Hit:9 https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy InRelease\n",
+      "Hit:10 https://ppa.launchpadcontent.net/graphics-drivers/ppa/ubuntu jammy InRelease\n",
+      "Hit:11 https://ppa.launchpadcontent.net/ubuntugis/ppa/ubuntu jammy InRelease\n",
+      "Fetched 3,632 B in 1s (2,929 B/s)\n",
+      "Reading package lists... Done\n",
+      "W: Skipping acquire of configured file 'main/source/Sources' as repository 'https://r2u.stat.illinois.edu/ubuntu jammy InRelease' does not seem to provide it (sources.list entry misspelt?)\n",
+      "Reading package lists... Done\n",
+      "Building dependency tree... Done\n",
+      "Reading state information... Done\n",
+      "fonts-noto-cjk is already the newest version (1:20220127+repack1-1).\n",
+      "0 upgraded, 0 newly installed, 0 to remove and 43 not upgraded.\n",
+      "/usr/share/fonts: caching, new cache contents: 0 fonts, 2 dirs\n",
+      "/usr/share/fonts/opentype: caching, new cache contents: 0 fonts, 1 dirs\n",
+      "/usr/share/fonts/opentype/noto: caching, new cache contents: 30 fonts, 0 dirs\n",
+      "/usr/share/fonts/truetype: caching, new cache contents: 0 fonts, 2 dirs\n",
+      "/usr/share/fonts/truetype/humor-sans: caching, new cache contents: 1 fonts, 0 dirs\n",
+      "/usr/share/fonts/truetype/liberation: caching, new cache contents: 16 fonts, 0 dirs\n",
+      "/usr/local/share/fonts: caching, new cache contents: 0 fonts, 0 dirs\n",
+      "/root/.local/share/fonts: skipping, no such directory\n",
+      "/root/.fonts: skipping, no such directory\n",
+      "/usr/share/fonts/opentype: skipping, looped directory detected\n",
+      "/usr/share/fonts/truetype: skipping, looped directory detected\n",
+      "/usr/share/fonts/opentype/noto: skipping, looped directory detected\n",
+      "/usr/share/fonts/truetype/humor-sans: skipping, looped directory detected\n",
+      "/usr/share/fonts/truetype/liberation: skipping, looped directory detected\n",
+      "/var/cache/fontconfig: cleaning cache directory\n",
+      "/root/.cache/fontconfig: not cleaning non-existent cache directory\n",
+      "/root/.fontconfig: not cleaning non-existent cache directory\n",
+      "fc-cache: succeeded\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "%cd /content/makePeriodicTableEPUB\n",
+    "!git pull"
+   ],
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "lyQ1nNVPqNpx",
+    "outputId": "4a81e99d-04eb-4f14-9ec1-e600d3c4b7e1"
+   },
+   "id": "lyQ1nNVPqNpx",
+   "execution_count": 20,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "/content/makePeriodicTableEPUB\n",
+      "remote: Enumerating objects: 5, done.\u001b[K\n",
+      "remote: Counting objects: 100% (5/5), done.\u001b[K\n",
+      "remote: Compressing objects: 100% (5/5), done.\u001b[K\n",
+      "remote: Total 5 (delta 1), reused 0 (delta 0), pack-reused 0 (from 0)\u001b[K\n",
+      "Unpacking objects: 100% (5/5), 6.02 KiB | 3.01 MiB/s, done.\n",
+      "From https://github.com/pun2beam/makePeriodicTableEPUB\n",
+      "   0b0e4ea..838a552  main       -> origin/main\n",
+      " * [new branch]      codex/fix-metadata-language-error-in-epub -> origin/codex/fix-metadata-language-error-in-epub\n",
+      "Updating 0b0e4ea..838a552\n",
+      "Fast-forward\n",
+      " scripts/build_epub.py | 29 \u001b[32m++++++++++++++++++++++++++++\u001b[m\u001b[31m-\u001b[m\n",
+      " 1 file changed, 28 insertions(+), 1 deletion(-)\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39314563",
+   "metadata": {
+    "id": "39314563"
+   },
+   "source": [
+    "## Optional: Mount Google Drive\n",
+    "Uncomment the cell below if you want the generated assets to be saved to Google Drive instead of the Colab ephemeral filesystem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "28a48dcc",
+   "metadata": {
+    "id": "28a48dcc"
+   },
+   "outputs": [],
+   "source": [
+    "# from google.colab import drive\n",
+    "# drive.mount('/content/drive')\n",
+    "# %cd /content/drive/MyDrive/path/to/your/workdir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51a46bd9",
+   "metadata": {
+    "id": "51a46bd9"
+   },
+   "source": [
+    "## Build the EPUB\n",
+    "The commands below follow the workflow defined in Section 4 of the specification. They can be rerun to refresh the data or rebuild the package after modifying templates or scripts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [],
+   "metadata": {
+    "id": "WAKr7eeO80Q6"
+   },
+   "id": "WAKr7eeO80Q6",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "6733a2de",
+   "metadata": {
+    "id": "6733a2de",
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "outputId": "73ba6b99-c53a-4099-aa38-e2699b009f98"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "2025-09-23 19:02:12,322 INFO __main__: Starting fetch\n",
+      "2025-09-23 19:02:12,707 INFO __main__: Fetched REST API page html\n",
+      "2025-09-23 19:02:12,712 INFO __main__: Saved raw data\n",
+      "Wrote normalized data to data/tables.json\n",
+      "2025-09-23 19:02:14,135 INFO __main__: Starting fetch\n",
+      "2025-09-23 19:02:14,356 INFO __main__: Fetched REST API page html\n",
+      "2025-09-23 19:02:14,361 INFO __main__: Saved raw data\n",
+      "2025-09-23 19:02:14,431 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:14,432 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:14,499 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:14,500 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:14,567 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:14,568 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:14,633 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:14,634 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:14,702 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:14,703 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:14,768 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:14,769 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:14,839 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:14,840 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:14,905 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:14,906 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:14,973 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:14,974 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,040 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,041 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,112 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,113 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,184 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,185 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,256 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,257 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,327 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,329 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,402 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,403 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,474 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,475 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,544 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,545 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,612 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,613 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,682 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,684 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,752 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,753 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,822 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,823 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,890 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,891 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:15,963 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:15,964 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,035 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,036 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,105 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,106 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,175 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,176 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,244 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,246 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,318 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,320 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,395 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,396 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,468 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,469 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,537 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,539 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,612 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,613 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,686 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,687 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,759 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,760 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,831 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,832 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,902 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,904 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:16,973 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:16,974 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,041 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,042 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,110 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,111 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,179 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,180 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,246 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,247 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,315 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,315 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,382 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,383 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,453 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,454 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,520 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,521 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,588 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,589 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,654 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,655 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,721 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,722 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,788 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,789 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,855 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,856 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,921 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,922 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:17,989 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:17,990 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,059 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,060 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,126 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,127 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,194 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,195 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,261 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,261 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,329 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,330 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,396 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,396 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,462 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,463 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,530 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,531 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,601 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,602 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,668 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,669 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,736 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,736 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,803 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,804 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,871 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,872 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:18,938 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:18,939 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,005 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,006 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,073 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,074 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,142 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,142 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,210 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,210 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,277 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,278 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,345 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,346 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,412 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,413 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,481 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,482 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,547 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,548 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,614 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,615 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,683 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,683 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,751 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,752 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,819 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,820 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,888 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,889 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:19,958 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:19,959 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,025 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,026 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,092 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,092 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,157 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,158 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,223 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,224 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,293 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,294 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,361 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,362 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,429 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,430 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,498 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,498 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,566 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,567 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,634 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,635 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,702 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,703 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,771 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,772 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,839 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,840 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,908 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,909 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:20,974 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:20,975 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,042 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,043 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,111 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,112 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,182 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,183 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,250 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,250 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,315 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,316 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,382 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,383 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,449 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,450 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,517 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,517 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,583 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,584 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,652 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,653 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,718 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,719 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,786 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,787 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,856 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,857 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,924 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,925 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:21,993 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:21,994 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:22,061 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:22,062 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:22,128 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:22,129 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:22,196 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:22,197 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:22,266 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:22,267 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:22,333 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:22,334 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:22,401 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:22,402 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:22,470 INFO __main__: Fetched REST API summary\n",
+      "2025-09-23 19:02:22,471 INFO __main__: Fetched element summary\n",
+      "2025-09-23 19:02:22,476 INFO __main__: Wrote element summaries\n",
+      "Wrote cover SVG to assets/gen/cover.svg\n",
+      "Wrote attribution XHTML to book/OEBPS/attribution.xhtml\n",
+      "Rasterized cover to book/dist/cover_2560x1600.jpg\n",
+      "Built EPUB at book/dist/PeriodicTable.ja.epub\n"
+     ]
+    }
+   ],
+   "source": [
+    "#@title Run data fetch, normalization, and build scripts\n",
+    "# !python scripts/fetch_wiki.py --lang en --page \"List of chemical elements\" --output-file list-of-chemical-elements-en-rest.json\n",
+    "!python scripts/fetch_wiki.py --lang ja --page \"元素の一覧\" --output-file yuan-su-noyi-lan-ja-rest.json\n",
+    "# !python scripts/normalize.py\n",
+    "!python scripts/normalize.py --input data/raw/yuan-su-noyi-lan-ja-rest.json\n",
+    "!python scripts/fetch_wiki.py --lang ja --page \"元素の一覧\" --elements-from data/tables.json --elements-json data/elements.ja.json\n",
+    "!python scripts/build_cover_svg.py --in data/tables.json --out assets/gen/cover.svg\n",
+    "!python scripts/license_attribution.py --out book/OEBPS/attribution.xhtml\n",
+    "!python scripts/rasterize_cover.py --in assets/gen/cover.svg --out book/dist/cover_2560x1600.jpg --width 1600 --height 2560\n",
+    "# !python scripts/build_epub.py --cover book/dist/cover_2560x1600.jpg --out book/dist/PeriodicTable.en.epub --element-data data/elements.en.json\n",
+    "!python scripts/build_epub.py --cover book/dist/cover_2560x1600.jpg --out book/dist/PeriodicTable.ja.epub --element-data data/elements.ja.json\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6e5dd14",
+   "metadata": {
+    "id": "e6e5dd14"
+   },
+   "source": [
+    "## Inspect generated files\n",
+    "Run the following cell to list the distribution folder and confirm that the EPUB and cover JPEG were produced successfully."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "2509c2e8",
+   "metadata": {
+    "id": "2509c2e8",
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "outputId": "eee5e471-4db3-4d54-81bc-3980e03dee50"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "ls: cannot access 'book/dist': No such file or directory\n"
+     ]
+    }
+   ],
+   "source": [
+    "#@title Check build outputs\n",
+    "!ls -lh book/dist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "!rm -rf /content/makePeriodicTableEPUB/data\n",
+    "!rm -rf /content/makePeriodicTableEPUB/book/\n",
+    "!rm -rf /content/makePeriodicTableEPUB/makePeriodicTableEPUB/\n"
+   ],
+   "metadata": {
+    "id": "LAYSUhT0kMoQ"
+   },
+   "id": "LAYSUhT0kMoQ",
+   "execution_count": 23,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "colab_build.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- update README instructions to illustrate using the new --output-file option when fetching wiki data
- align the Colab notebook commands with the README so both specify deterministic raw filenames

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68d3ac90bb54833180806eeb8d2f78ff