### PR TITLE
Add localization support for cover and attribution content

### DIFF
--- a/assets/templates/cover.svg.j2
+++ b/assets/templates/cover.svg.j2
@@ -16,13 +16,13 @@
 
     <text class="title">
       <textPath href="#arcTitle" xlink:href="#arcTitle" startOffset="50%" text-anchor="middle">
-        元 素 周 期 表
+        {{ title_text }}
       </textPath>
     </text>
 
     <text class="subtitle">
       <textPath href="#arcSubtitle" xlink:href="#arcSubtitle" startOffset="50%" text-anchor="middle">
-        Reference Edition for Kindle
+        {{ subtitle_text }}
       </textPath>
     </text>
     <defs>

--- a/scripts/build_cover_svg.py
+++ b/scripts/build_cover_svg.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, Iterable, List, Optional
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
+from localization import get_localized_strings
+
 LAYOUT_WIDTH = 2560
 LAYOUT_HEIGHT = 1600
 COVER_WIDTH = 1600
@@ -116,7 +118,7 @@ def make_arc_path_d(
     )
 
 
-def render_svg(template_path: Path, cells: List[Cell]) -> str:
+def render_svg(template_path: Path, cells: List[Cell], strings: Dict[str, str]) -> str:
     env = Environment(
         loader=FileSystemLoader(template_path.parent),
         autoescape=select_autoescape(enabled_extensions=("svg", "xml")),
@@ -146,6 +148,8 @@ def render_svg(template_path: Path, cells: List[Cell]) -> str:
         subtitle_y=cx - r_subtitle / 1.414,
         atom_x=cx,
         atom_y=cy,
+        title_text=strings["cover_arc_title"],
+        subtitle_text=strings["cover_arc_subtitle"],
     )
 
 
@@ -166,7 +170,8 @@ def main() -> int:
     data = json.loads(args.data.read_text(encoding="utf-8"))
     elements = data["elements"]
     cells = build_cells(elements)
-    svg = render_svg(args.template, cells)
+    strings = get_localized_strings(data.get("meta", {}).get("language"))
+    svg = render_svg(args.template, cells, strings)
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(svg, encoding="utf-8")
     print(f"Wrote cover SVG to {args.out}")

--- a/scripts/license_attribution.py
+++ b/scripts/license_attribution.py
@@ -6,21 +6,24 @@ from __future__ import annotations
 import argparse
 import json
 from datetime import datetime, timezone
+from html import escape
 from pathlib import Path
 from typing import List
+
+from localization import get_localized_strings
 
 ATTRIBUTION_TEMPLATE = """<?xml version='1.0' encoding='utf-8'?>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <title>Attribution</title>
+    <title>{page_title}</title>
     <link rel="stylesheet" href="css/style.css" type="text/css"/>
   </head>
   <body>
-    <h1>Sources &amp; Licensing</h1>
-    <p>All textual content originates from the Wikipedia and is distributed under the terms of the Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0).</p>
-    <p>Retrieved on {{retrieved}}.</p>
+    <h1>{heading}</h1>
+    <p>{intro}</p>
+    <p>{retrieved_text}</p>
     <ul>
-    {{items}}
+    {items}
     </ul>
   </body>
 </html>
@@ -41,10 +44,21 @@ def main() -> int:
     args = parser.parse_args()
 
     data = json.loads(args.data.read_text(encoding="utf-8"))
+    strings = get_localized_strings(data.get("meta", {}).get("language"))
     elements = data["elements"]
     items_html = build_items(elements)
     retrieved = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    xhtml = ATTRIBUTION_TEMPLATE.replace("{{items}}", items_html).replace("{{retrieved}}", retrieved)
+    page_title = escape(strings["sources_title"])
+    heading = page_title
+    intro = escape(strings["sources_intro"])
+    retrieved_text = escape(strings["sources_retrieved"].format(retrieved=retrieved))
+    xhtml = ATTRIBUTION_TEMPLATE.format(
+        page_title=page_title,
+        heading=heading,
+        intro=intro,
+        retrieved_text=retrieved_text,
+        items=items_html,
+    )
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(xhtml, encoding="utf-8")
     print(f"Wrote attribution XHTML to {args.out}")

--- a/scripts/localization.py
+++ b/scripts/localization.py
@@ -1,0 +1,89 @@
+"""Utility helpers for retrieving localized strings."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+DEFAULT_LANGUAGE = "en"
+
+# Default/localized strings are organised so that languages can override only the
+# keys they need.  When new languages are introduced, simply add an entry here
+# with the appropriate overrides.
+_BASE_STRINGS: Dict[str, Dict[str, str]] = {
+    "en": {
+        "cover_page_title": "Cover",
+        "cover_nav_label": "Cover",
+        "cover_image_alt": "Periodic Table cover",
+        "cover_arc_title": "PERIODIC TABLE",
+        "cover_arc_subtitle": "Reference Edition for Kindle",
+        "toc_heading": "Contents",
+        "element_profiles_title": "Element Profiles",
+        "element_profiles_nav_label": "Element Profiles",
+        "element_profiles_intro": "Concise summaries for each element sourced from Wikipedia.",
+        "element_profiles_source_note": "Each entry links to the corresponding Wikipedia article under CC BY-SA 4.0.",
+        "sources_title": "Sources & Licensing",
+        "sources_nav_label": "Sources & Licensing",
+        "sources_intro": (
+            "All textual content originates from the Wikipedia and is distributed under the terms of the "
+            "Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0)."
+        ),
+        "sources_retrieved": "Retrieved on {retrieved}.",
+    },
+    "ja": {
+        "cover_page_title": "表紙",
+        "cover_nav_label": "表紙",
+        "cover_image_alt": "元素周期表の表紙",
+        "cover_arc_title": "元 素 周 期 表",
+        "cover_arc_subtitle": "Kindle リファレンス版",
+        "toc_heading": "目次",
+        "element_profiles_title": "元素プロフィール",
+        "element_profiles_nav_label": "元素プロフィール",
+        "element_profiles_intro": "各元素の簡潔な概要をWikipediaから収録しています。",
+        "element_profiles_source_note": "各項目はCC BY-SA 4.0の条件で対応するWikipedia記事にリンクしています。",
+        "sources_title": "出典とライセンス",
+        "sources_nav_label": "出典とライセンス",
+        "sources_intro": (
+            "本文のテキストはすべてWikipediaに由来し、Creative Commons Attribution-ShareAlike 4.0 International "
+            "License (CC BY-SA 4.0) の条件で配布されています。"
+        ),
+        "sources_retrieved": "取得日: {retrieved}。",
+    },
+}
+
+
+def _select_language(language: str | None) -> str:
+    """Return the best-match language key for the provided tag."""
+
+    if not language:
+        return DEFAULT_LANGUAGE
+    candidate = str(language).strip().lower()
+    if not candidate:
+        return DEFAULT_LANGUAGE
+    if candidate in _BASE_STRINGS:
+        return candidate
+    primary = candidate.split("-", 1)[0]
+    if primary in _BASE_STRINGS:
+        return primary
+    return DEFAULT_LANGUAGE
+
+
+def get_localized_strings(language: str | None) -> Dict[str, str]:
+    """Return a merged dictionary of localized strings for ``language``.
+
+    The returned dictionary always contains all keys defined in the default
+    language so callers can rely on the presence of required text snippets.
+    """
+
+    selected = _select_language(language)
+    base = dict(_BASE_STRINGS[DEFAULT_LANGUAGE])
+    if selected != DEFAULT_LANGUAGE:
+        base.update(_BASE_STRINGS[selected])
+    # Ensure navigation labels default to the corresponding titles when they are
+    # not explicitly overridden.
+    base.setdefault("element_profiles_nav_label", base["element_profiles_title"])
+    base.setdefault("sources_nav_label", base["sources_title"])
+    base.setdefault("cover_nav_label", base["cover_page_title"])
+    return base
+
+
+__all__ = ["get_localized_strings", "DEFAULT_LANGUAGE"]


### PR DESCRIPTION
## Summary
- centralize multi-language strings in a new localization helper to simplify future translations
- update EPUB build scripts to use localized labels for the cover, element index, navigation, and attribution pages
- render the cover SVG template with localized title/subtitle text so the artwork matches the selected language

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68d3c1d11a3483319158750790771b08