### PR TITLE
Expand cover arc angles for longer titles

### DIFF
--- a/scripts/build_cover_svg.py
+++ b/scripts/build_cover_svg.py
@@ -131,8 +131,12 @@ def render_svg(template_path: Path, cells: List[Cell], strings: Dict[str, str]) 
     base = min(LAYOUT_WIDTH, LAYOUT_HEIGHT)
     r_title = base / 8
     r_subtitle = r_title + 120
-    theta_start = -75.0
-    theta_end = 120.0
+    # Allow a wider arc so that long strings (e.g., "PERIODIC TABLE") don't
+    # have their first or last characters clipped when rendered along the
+    # circle.  Expanding both ends maintains the centered alignment while
+    # giving the text a bit more breathing room.
+    theta_start = -95.0
+    theta_end = 140.0
 
     return template.render(
         cells=[cell.__dict__ for cell in cells],


### PR DESCRIPTION
## Summary
- widen the arc angles used for cover title and subtitle rendering
- add documentation to explain the wider span prevents clipping long strings

## Testing
- python3 scripts/build_cover_svg.py --data assets/sample_data.json *(fails: assets/sample_data.json is missing in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c999ab008331801c17961f6fb979