### PR TITLE
Adjust element metadata table layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -24,6 +24,20 @@ td, th {
   text-align: center;
 }
 
+.element-meta {
+  width: 100%;
+  max-width: 28em;
+  margin: 0 0 1.5em;
+}
+
+.element-meta th {
+  text-align: left;
+}
+
+.element-meta td {
+  text-align: right;
+}
+
 .periodic-grid {
   font-size: 0.85em;
 }


### PR DESCRIPTION
## Summary
- constrain element metadata tables to a readable width suited for Kindle devices
- align metadata labels to the left and values to the right for improved clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3d89839648331bac6ef369ab5c1c3