### PR TITLE
Detect system Japanese font for cover

### DIFF
--- a/assets/templates/cover.svg.j2
+++ b/assets/templates/cover.svg.j2
@@ -1,6 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{ cover_width }}" height="{{ cover_height }}" viewBox="0 0 {{ cover_width }} {{ cover_height }}">
   <style>
-    text { font-family: 'Helvetica Neue', Helvetica, Arial, 'Noto Sans', 'DejaVu Sans', 'Noto Sans CJK JP', 'Noto Sans JP', sans-serif; }
+    text { font-family: {{ body_font_stack | safe }}; }
+    .title, .subtitle { font-family: {{ title_font_stack | safe }}; }
     .title { font-size: 72px; font-weight: 700; letter-spacing: 4px; text-anchor: middle; }
     .subtitle { font-size: 36px; font-weight: 400; text-anchor: middle; }
     .cell { fill: #fdfdfd; stroke: #000; stroke-width: 2; }


### PR DESCRIPTION
## Summary
- detect an installed Japanese-capable font (via fontconfig or OS defaults) when generating the cover SVG so CairoSVG uses a glyph-complete family instead of bundled assets
- inject the computed font-family stack into the cover template and drop the embedded Noto Sans files

## Testing
- python scripts/build_cover_svg.py --data /tmp/data.json --out /tmp/cover.svg
- python scripts/rasterize_cover.py --in /tmp/cover.svg --out /tmp/cover.jpg --width 1600 --height 2560

------
https://chatgpt.com/codex/tasks/task_e_68d3e09715b08331b4b69bdf57d66316