### PR TITLE
Adjust element tables for origin and English name

### DIFF
--- a/scripts/build_epub.py
+++ b/scripts/build_epub.py
@@ -88,7 +88,13 @@ def render_element_page(element: Dict[str, object], strings: Dict[str, str]) -> 
         ),
         (strings["element_meta_category"], element.get("category")),
         (strings["element_meta_phase_stp"], element.get("phase")),
+        (strings["element_meta_origin"], element.get("origin")),
     ]
+
+    english_label = strings.get("element_meta_name_en")
+    english_name = element.get("name_en")
+    if english_label and english_name not in (None, ""):
+        table_fields.append((english_label, english_name))
     table_rows = "".join(
         "<tr><th scope=\"row\">{label}</th><td>{value}</td></tr>".format(
             label=escape(str(label)),
@@ -103,9 +109,7 @@ def render_element_page(element: Dict[str, object], strings: Dict[str, str]) -> 
         else ""
     )
 
-    additional_pairs = [
-        (strings["element_meta_origin"], element.get("origin")),
-    ]
+    additional_pairs = []
     additional_html = "".join(
         f"<dt>{escape(str(label))}</dt><dd>{escape(str(value))}</dd>"
         for label, value in additional_pairs

--- a/scripts/localization.py
+++ b/scripts/localization.py
@@ -58,6 +58,7 @@ _BASE_STRINGS: Dict[str, Dict[str, str]] = {
         "element_meta_category": "分類",
         "element_meta_phase_stp": "標準状態での相",
         "element_meta_origin": "名称の由来",
+        "element_meta_name_en": "英語名",
         "sources_title": "出典とライセンス",
         "sources_nav_label": "出典とライセンス",
         "sources_intro": (


### PR DESCRIPTION
## Summary
- include the origin field in the element metadata tables instead of rendering it as a separate definition list
- expose an additional metadata row for the English name when Japanese localisation strings are active

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68d3fac1cb508331a76583288f69eb37