### PR TITLE
Adjust cover symbol font size per language

### DIFF
--- a/assets/templates/cover.svg.j2
+++ b/assets/templates/cover.svg.j2
@@ -5,7 +5,7 @@
     .title { font-size: 72px; font-weight: 700; letter-spacing: 4px; text-anchor: middle; }
     .subtitle { font-size: 36px; font-weight: 400; text-anchor: middle; }
     .cell { fill: #fdfdfd; stroke: #000; stroke-width: 2; }
-    .symbol { font-size: 82px; font-weight: 900; text-anchor: middle; dominant-baseline: middle; }
+    .symbol { font-size: {{ symbol_font_size }}px; font-weight: 900; text-anchor: middle; dominant-baseline: middle; }
     .atomic-number { font-size: 28px; font-weight: 600; }
   </style>
   <rect x="0" y="0" width="{{ cover_width }}" height="{{ cover_height }}" fill="#ffffff"/>

--- a/scripts/build_cover_svg.py
+++ b/scripts/build_cover_svg.py
@@ -34,6 +34,12 @@ DEFAULT_SANS_FALLBACK = [
     "sans-serif",
 ]
 
+DEFAULT_SYMBOL_FONT_SIZE = 82
+_SYMBOL_FONT_SIZE_BY_LANGUAGE = {
+    "en": 78,
+    "ja": 82,
+}
+
 LAYOUT_WIDTH = 2560
 LAYOUT_HEIGHT = 1600
 COVER_WIDTH = 1600
@@ -284,6 +290,13 @@ def _compute_font_families(language: Optional[str]) -> Dict[str, str]:
     }
 
 
+def _compute_symbol_font_size(language: Optional[str]) -> int:
+    primary_tag = _language_primary_tag(language)
+    if primary_tag and primary_tag in _SYMBOL_FONT_SIZE_BY_LANGUAGE:
+        return _SYMBOL_FONT_SIZE_BY_LANGUAGE[primary_tag]
+    return DEFAULT_SYMBOL_FONT_SIZE
+
+
 def render_svg(
     template_path: Path,
     cells: List[Cell],
@@ -329,6 +342,7 @@ def render_svg(
         subtitle_text=strings["cover_arc_subtitle"],
         title_font_stack=font_families["title_font_stack"],
         body_font_stack=font_families["body_font_stack"],
+        symbol_font_size=_compute_symbol_font_size(language),
     )
 
 


### PR DESCRIPTION
## Summary
- allow the cover template to receive a configurable symbol font size
- choose symbol font sizes per language, shrinking English symbols to avoid overflow

## Testing
- python -m compileall scripts/build_cover_svg.py assets/templates/cover.svg.j2

------
https://chatgpt.com/codex/tasks/task_e_68d4059c9d408331b143fbf20e9da063